### PR TITLE
Use newer version of bcrypt package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/NateFerrero/amna",
   "dependencies": {
-    "bcrypt": "0.7.x",
+    "bcrypt": "0.8.x",
     "body-parser": "1.3.x",
     "bookshelf": "0.7.x",
     "connect-mongo": "0.4.x",


### PR DESCRIPTION
Seems that we should use >= 0.8.x version of bcrypt https://www.npmjs.com/package/bcrypt#version-compatibility
